### PR TITLE
Posting keyboard events is deprecated in 10.9

### DIFF
--- a/ext/accessibility/core/core.c
+++ b/ext/accessibility/core/core.c
@@ -638,6 +638,9 @@ static
 VALUE
 rb_acore_post(VALUE self, VALUE events)
 {
+#if MAC_OS_X_VERSION_MIN_ALLOWED <= MAC_OS_X_VERSION_10_9
+  rb_raise(rb_eRuntimeError, "Posting keyboard events is deprecated in 10.9 and later");
+#else
   events = rb_ary_to_ary(events);
   long length = RARRAY_LEN(events);
   useconds_t sleep_time = NUM2DBL(rb_ivar_get(rb_cElement, ivar_key_rate)) * 100000;
@@ -671,6 +674,7 @@ rb_acore_post(VALUE self, VALUE events)
   }
 
   return self;
+#endif
 }
 
 


### PR DESCRIPTION
As a temporary fix I am just raising an exception for now. For the
Future we have to find a different way. The only thing that comes to
mind right now is using CGEventCreateKeyboardEvent even trough that
can't be used to send a keyboard event to a specific element.
