### PR TITLE
add two more functions to NSWorkspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ pkg/
 Gemfile.lock
 test/fixture
 Makefile
-
+vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
-source 'https://rubygems.org/'
+#source 'https://rubygems.org/'
+source 'http://rubygems-amac.ecs.ads.autodesk.com:9292'
 gemspec
 
 group :development do

--- a/accessibility_core.gemspec
+++ b/accessibility_core.gemspec
@@ -22,6 +22,7 @@ Originally extracted from the AXElements project.
   s.has_rdoc    = 'yard'
 
   s.extensions  = [
+                   'ext/accessibility/mkmf_helper.rb',
                    'ext/accessibility/core/extconf.rb',
                    'ext/accessibility/bridge/extconf.rb',
                    'ext/accessibility/extras/extconf.rb',

--- a/ext/accessibility/bridge/bridge.c
+++ b/ext/accessibility/bridge/bridge.c
@@ -195,27 +195,33 @@ AXValueRef unwrap_value_range(VALUE val) { UNWRAP_VALUE(CFRange, kAXValueCFRange
 VALUE
 wrap_value(AXValueRef value)
 {
-  switch (AXValueGetType(value))
-    {
-    case kAXValueIllegalType:
-      rb_raise(rb_eArgError, "cannot wrap %s objects", rb_class2name(CLASS_OF(value)));
-    case kAXValueCGPointType:
-      return wrap_value_point(value);
-    case kAXValueCGSizeType:
-      return wrap_value_size(value);
-    case kAXValueCGRectType:
-      return wrap_value_rect(value);
-    case kAXValueCFRangeType:
-      return wrap_value_range(value);
-    case kAXValueAXErrorType:
-      return wrap_value_error(value);
-    default:
-      // TODO better error message
-      rb_raise(
-	       rb_eRuntimeError,
-	       "Either accessibility_core is out of date or your system has had a serious error"
-	       );
-    }
+  AXValueType type = AXValueGetType(value);
+  
+  if (type == kAXValueIllegalType) {
+    rb_raise(rb_eArgError, "cannot wrap %s objects", rb_class2name(CLASS_OF(value)));
+  }
+  else if (type == kAXValueCGPointType) {
+    return wrap_value_point(value);
+  }
+  else if (type == kAXValueCGSizeType) {
+    return wrap_value_size(value);
+  }
+  else if (type == kAXValueCGRectType) {
+    return wrap_value_rect(value);
+  }
+  else if (type == kAXValueCFRangeType) {
+    return wrap_value_range(value);
+  }
+  else if (type == kAXValueAXErrorType) {
+    return wrap_value_error(value);
+  }
+  else {
+    // TODO better error message
+    rb_raise(
+       rb_eRuntimeError,
+       "Either accessibility_core is out of date or your system has had a serious error"
+       );
+  }
 
   return Qnil; // unreachable
 }

--- a/ext/accessibility/bridge/extconf.rb
+++ b/ext/accessibility/bridge/extconf.rb
@@ -1,4 +1,4 @@
-require 'mkmf'
+require '../mkmf_helper'
 
 $CFLAGS << ' -std=c99 -Wall -Werror -pedantic -ObjC'
 $LIBS   << ' -framework CoreFoundation -framework ApplicationServices -framework Cocoa'

--- a/ext/accessibility/core/core.c
+++ b/ext/accessibility/core/core.c
@@ -139,7 +139,7 @@ handle_error(VALUE self, AXError code)
 	rb_raise(
 		 rb_eRuntimeError,
 		 "accessibility_core majorly goofed [%d]",
-		 code
+		 (int)code
 		 );
       }
   }

--- a/ext/accessibility/core/extconf.rb
+++ b/ext/accessibility/core/extconf.rb
@@ -1,4 +1,4 @@
-require 'mkmf'
+require '../mkmf_helper'
 
 $CFLAGS << ' -std=c99 -Wall -Werror -pedantic -ObjC'
 $LIBS   << ' -framework CoreFoundation -framework ApplicationServices -framework Cocoa'

--- a/ext/accessibility/extras/extconf.rb
+++ b/ext/accessibility/extras/extconf.rb
@@ -1,4 +1,4 @@
-require 'mkmf'
+require '../mkmf_helper'
 
 $CFLAGS << ' -std=c99 -Wall -Werror -pedantic -ObjC'
 $LIBS   << ' -framework CoreFoundation -framework Cocoa -framework IOKit'

--- a/ext/accessibility/extras/extras.c
+++ b/ext/accessibility/extras/extras.c
@@ -338,14 +338,15 @@ VALUE
 rb_workspace_launch_at_path(VALUE self, VALUE bundle_path)
 {
     NSURL* bundle_url = [NSURL fileURLWithPath:unwrap_nsstring(bundle_path)];
-    if (!bundle_url)
+    if (bundle_url == nil)
         return Qnil;
 
+    NSError *err = nil;
     return wrap_app([[NSWorkspace sharedWorkspace] 
             launchApplicationAtURL:bundle_url
                            options:NSWorkspaceLaunchAsync
-                     configuration:nil
-                             error:nil]);
+                     configuration:@{}
+                             error:&err]);
 }
 
 static
@@ -832,8 +833,6 @@ Init_extras()
     WORKSPACE_CONST("NSWorkspaceLaunchWithoutAddingToRecents",   NSWorkspaceLaunchWithoutAddingToRecents);
     WORKSPACE_CONST("NSWorkspaceLaunchWithoutActivation",        NSWorkspaceLaunchWithoutActivation);
     WORKSPACE_CONST("NSWorkspaceLaunchAsync",                    NSWorkspaceLaunchAsync);
-    WORKSPACE_CONST("NSWorkspaceLaunchAllowingClassicStartup",   NSWorkspaceLaunchAllowingClassicStartup);
-    WORKSPACE_CONST("NSWorkspaceLaunchPreferringClassic",        NSWorkspaceLaunchPreferringClassic);
     WORKSPACE_CONST("NSWorkspaceLaunchNewInstance",              NSWorkspaceLaunchNewInstance);
     WORKSPACE_CONST("NSWorkspaceLaunchAndHide",                  NSWorkspaceLaunchAndHide);
     WORKSPACE_CONST("NSWorkspaceLaunchAndHideOthers",            NSWorkspaceLaunchAndHideOthers);

--- a/ext/accessibility/extras/extras.c
+++ b/ext/accessibility/extras/extras.c
@@ -489,7 +489,7 @@ static
 VALUE
 rb_screen_frame(VALUE self)
 {
-  return wrap_rect([unwrap_screen(self) frame]);
+  return wrap_rect(NSRectToCGRect([unwrap_screen(self) frame]));
 }
 
 #endif
@@ -518,7 +518,7 @@ rb_screen_wake(VALUE self, SEL sel)
     }
   }
 
-  CGPoint      mouse = [NSEvent mouseLocation];
+  CGPoint      mouse = NSPointToCGPoint([NSEvent mouseLocation]);
   IOGPoint     point = { mouse.x, mouse.y };
   unsigned int flags = (unsigned int)[NSEvent modifierFlags];
   NXEventData   data;

--- a/ext/accessibility/extras/extras.c
+++ b/ext/accessibility/extras/extras.c
@@ -329,7 +329,7 @@ rb_workspace_path_for_bundle_id(VALUE self, VALUE bundle_id)
         absolutePathForAppBundleWithIdentifier:identifier];
 
     [identifier release];
-    return wrap_nsstring(path);
+    return path ? wrap_nsstring(path) : Qnil;
 }
 
 

--- a/ext/accessibility/highlighter/extconf.rb
+++ b/ext/accessibility/highlighter/extconf.rb
@@ -1,4 +1,4 @@
-require 'mkmf'
+require '../mkmf_helper'
 
 $CFLAGS << ' -std=c99 -Wall -Werror -pedantic -ObjC'
 $LIBS   << ' -framework CoreFoundation -framework ApplicationServices -framework Cocoa'

--- a/ext/accessibility/highlighter/highlighter.c
+++ b/ext/accessibility/highlighter/highlighter.c
@@ -54,7 +54,7 @@ CGRect
 flip(CGRect rect)
 {
   double screen_height = NSMaxY([[NSScreen mainScreen] frame]);
-  rect.origin.y        = screen_height - NSMaxY(rect);
+  rect.origin.y        = screen_height - NSMaxY(NSRectFromCGRect(rect));
   return rect;
 }
 
@@ -69,7 +69,7 @@ rb_highlighter_new(int argc, VALUE* argv, VALUE self)
   bounds = flip(bounds); // we assume the rect is in the other co-ordinate system
 
   NSWindow* window =
-    [[NSWindow alloc] initWithContentRect:bounds
+    [[NSWindow alloc] initWithContentRect:NSRectFromCGRect(bounds)
                                 styleMask:NSBorderlessWindowMask
 		                  backing:NSBackingStoreBuffered
                                     defer:true];
@@ -89,7 +89,7 @@ rb_highlighter_new(int argc, VALUE* argv, VALUE self)
   [window setLevel:NSStatusWindowLevel];
   [window setBackgroundColor:color];
   [window setIgnoresMouseEvents:true];
-  [window setFrame:bounds display:false];
+  [window setFrame:NSRectFromCGRect(bounds) display:false];
   [window makeKeyAndOrderFront:NSApp];
   [window setReleasedWhenClosed:false];
 
@@ -132,7 +132,7 @@ static
 VALUE
 rb_highlighter_frame(VALUE self)
 {
-  return wrap_rect([unwrap_window(self) frame]);
+  return wrap_rect(NSRectToCGRect([unwrap_window(self) frame]));
 }
 
 static

--- a/ext/accessibility/mkmf_helper.rb
+++ b/ext/accessibility/mkmf_helper.rb
@@ -1,0 +1,9 @@
+require 'rbconfig'
+base_sdk = `xcrun --show-sdk-path`.chomp
+match_data = /MacOSX(\d+)\.(\d+)\.sdk/.match(base_sdk)
+minor_version = match_data[2].to_i
+# 10.11 is darwin 15
+darwin_version = 15 + (minor_version - 11)
+RbConfig::CONFIG['arch'] = "universal-darwin#{darwin_version}"
+RbConfig::CONFIG['rubyarchhdrdir'] = RbConfig::expand('$(rubyhdrdir)/$(arch)')
+require 'mkmf'

--- a/lib/accessibility/core/version.rb
+++ b/lib/accessibility/core/version.rb
@@ -6,6 +6,6 @@ module Accessibility
   # Namespace for `accessibility_core` specific classes
   module Core
     # return [String]
-    VERSION = '0.5.4'
+    VERSION = '0.5.5'
   end
 end

--- a/lib/accessibility/core/version.rb
+++ b/lib/accessibility/core/version.rb
@@ -6,6 +6,6 @@ module Accessibility
   # Namespace for `accessibility_core` specific classes
   module Core
     # return [String]
-    VERSION = '0.4.3'
+    VERSION = '0.5.3'
   end
 end

--- a/lib/accessibility/core/version.rb
+++ b/lib/accessibility/core/version.rb
@@ -6,6 +6,6 @@ module Accessibility
   # Namespace for `accessibility_core` specific classes
   module Core
     # return [String]
-    VERSION = '0.5.5'
+    VERSION = '0.5.6'
   end
 end

--- a/lib/accessibility/core/version.rb
+++ b/lib/accessibility/core/version.rb
@@ -6,6 +6,6 @@ module Accessibility
   # Namespace for `accessibility_core` specific classes
   module Core
     # return [String]
-    VERSION = '0.5.3'
+    VERSION = '0.5.4'
   end
 end

--- a/test/AXElementsTester/AXElementsTester/AXElementsTester-Info.plist
+++ b/test/AXElementsTester/AXElementsTester/AXElementsTester-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.axelements.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.2.1</string>
+	<key>CFBundleSignature</key>
+	<string>AXEL</string>
+	<key>CFBundleVersion</key>
+	<string>1.2.1</string>
+</dict>
+</plist>

--- a/test/AXElementsTester/AXElementsTester/AXElementsTester-Info.plist
+++ b/test/AXElementsTester/AXElementsTester/AXElementsTester-Info.plist
@@ -7,16 +7,22 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.axelements.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>com.marketcircle.${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
+	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.0</string>
 	<key>CFBundleSignature</key>
-	<string>AXEL</string>
+	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.2.1</string>
+	<string>1.0</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 </dict>
 </plist>

--- a/test/accessibility/core/core_test.rb
+++ b/test/accessibility/core/core_test.rb
@@ -339,6 +339,7 @@ class CoreTest < MiniTest::Unit::TestCase
   # of an element using other methods in the class; thus it is
   # an integration test.
   def test_post
+    skip if on_sea_lion?
     events = [[0x56,true], [0x56,false], [0x54,true], [0x54,false]]
     string = '42'
 

--- a/test/accessibility/extras/nsworkspace_test.rb
+++ b/test/accessibility/extras/nsworkspace_test.rb
@@ -40,10 +40,12 @@ class NSWorkspaceTest < MiniTest::Unit::TestCase
   end
 
   def test_launch_at_path
-      running = shared.launchApplicationAtURL '/Applications/TextEdit.app'
+      app = shared.launchApplicationAtURL '/Applications/TextEdit.app'
       spin 1
-      assert running != nil
-      assert running.processIdentifier != 0
+      assert app != nil
+      assert app.processIdentifier != 0
+      app.terminate
+      spin 0.2
   end
       
 end

--- a/test/accessibility/extras/nsworkspace_test.rb
+++ b/test/accessibility/extras/nsworkspace_test.rb
@@ -39,6 +39,11 @@ class NSWorkspaceTest < MiniTest::Unit::TestCase
       assert shared.absolutePathForAppBundleWithIdentifier(id) == '/Applications/TextEdit.app'
   end
 
+  def test_path_for_not_exist_bundle_id
+      id = 'not.exist.app'
+      assert shared.absolutePathForAppBundleWithIdentifier(id) == nil
+  end
+
   def test_launch_at_path
       app = shared.launchApplicationAtURL '/Applications/TextEdit.app'
       spin 1

--- a/test/accessibility/extras/nsworkspace_test.rb
+++ b/test/accessibility/extras/nsworkspace_test.rb
@@ -34,4 +34,16 @@ class NSWorkspaceTest < MiniTest::Unit::TestCase
     assert app.terminated?
   end
 
+  def test_path_for_bundle_id
+      id = 'com.apple.TextEdit'
+      assert shared.absolutePathForAppBundleWithIdentifier(id) == '/Applications/TextEdit.app'
+  end
+
+  def test_launch_at_path
+      running = shared.launchApplicationAtURL '/Applications/TextEdit.app'
+      spin 1
+      assert running != nil
+      assert running.processIdentifier != 0
+  end
+      
 end


### PR DESCRIPTION
I'm exposing two functions on NSWorkspace. My goal is to get a NSRunningApplication instance of the launching application. So that I can get its PID along with some other information. launchAppWithBundleIdentifier doesn't give me that.

Ran `rake` command, so far it passes all core extra and highlighter tests.
During testing,  I found the AXElementTester project build failed, the Info.plist file is missing in repo. so I added it. But I'm not sure if the version is correct.

Also `test_post` method failed on my 10.9.2 system, because it uses deprecated function. so I skip it on Sea Lion. (should I say Mavericks?)

Thanks for reviewing!
-Jonny