### PR TITLE
Fix typo in case of 'IOKitLib.h'

### DIFF
--- a/ext/accessibility/extras/extras.c
+++ b/ext/accessibility/extras/extras.c
@@ -2,7 +2,7 @@
 
 #include "../bridge/bridge.h"
 
-#import <IOKit/IOKitlib.h>
+#import <IOKit/IOKitLib.h>
 #import <IOKit/ps/IOPowerSources.h>
 #import <IOKit/ps/IOPSKeys.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>


### PR DESCRIPTION
I was scratching my head, trying to figure out why the gem was failing to compile on my new laptop, until I realized the filename was `IOKitLib.h` and I'd formatted it with a case-sensitive filesystem. It builds fine after changing this one line.