### PR TITLE
fix deprectaed symbol so that it builds under 10.12

### DIFF
--- a/ext/accessibility/highlighter/highlighter.c
+++ b/ext/accessibility/highlighter/highlighter.c
@@ -66,7 +66,7 @@ rb_highlighter_new(int argc, VALUE* argv, VALUE self)
   const CGRect bounds = flip(unwrap_rect(coerce_to_rect(argv[0])));
   NSWindow* const window =
       [[NSWindow alloc] initWithContentRect:NSRectFromCGRect(bounds)
-                                  styleMask:NSBorderlessWindowMask
+                                  styleMask:NSWindowStyleMaskBorderless
 		                    backing:NSBackingStoreBuffered
                                       defer:true];
 


### PR DESCRIPTION
Without this it fails to build under 10.12.  Seems like Apple just deprecated the old symbol.  Not sure the logic behind their change, but here's the updated one.